### PR TITLE
Add support for headdim = 96

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository provides an implementation of [FlashAttention](https://github.co
 Supports:
 
  - fwd and bwd
- - head dim 64, 128
+ - head dim 64, 96, 128
  - causal mask
  - gqa
  - varlen

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -17,7 +17,7 @@ pip install -v .
 batch_size=4
 num_heads=16
 num_heads_k=16
-hdims=(64 128)
+hdims=(64 96 128)
 seqlens=(512 1024 2048 4096 8192 16384 500 1000 2000 4000 8000 16000)
 # seqlens=(8192 16384 8000 16000)
 is_causals=(False True)

--- a/csrc/flash_attn/src/flash_bwd_hdim96_fp16_causal_sm75.cu
+++ b/csrc/flash_attn/src/flash_bwd_hdim96_fp16_causal_sm75.cu
@@ -1,0 +1,10 @@
+#include "flash_bwd_launch_template.h"
+
+#include <cutlass/numeric_types.h>
+
+using half_t = cutlass::half_t;
+
+template<>
+void run_mha_bwd_<96, true>(Flash_bwd_params &params) {
+    run_mha_bwd_hdim96<true>(params);
+}

--- a/csrc/flash_attn/src/flash_bwd_hdim96_fp16_sm75.cu
+++ b/csrc/flash_attn/src/flash_bwd_hdim96_fp16_sm75.cu
@@ -1,0 +1,10 @@
+#include "flash_bwd_launch_template.h"
+
+#include <cutlass/numeric_types.h>
+
+using half_t = cutlass::half_t;
+
+template<>
+void run_mha_bwd_<96, false>(Flash_bwd_params &params) {
+    run_mha_bwd_hdim96<false>(params);
+}

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -213,6 +213,12 @@ inline __device__ void compute_dq_1rowblock(
     Tensor tdQsdQ_copy = thr_copy_QKV.partition_S(sdQ);
     Tensor tdQgdQ_copy = thr_copy_QKV.partition_D(gdQ);
 
+    // Identity tensors for bound-checking the masked copies
+    Tensor cQ_identity = make_identity_tensor(make_shape(Int<kBlockM>{}, Int<kHeadDim>{}));
+    Tensor cK_identity = make_identity_tensor(make_shape(Int<kBlockN>{}, Int<kHeadDim>{}));
+    auto tCqQ = thr_copy_QKV.partition_S(cQ_identity);
+    auto tCqK = thr_copy_QKV.partition_S(cK_identity);
+
 
     // S = QK^T
     typename Kernel_traits::TiledMma_SdP tiled_mma_S;
@@ -323,11 +329,11 @@ inline __device__ void compute_dq_1rowblock(
 //    Mask<Is_causal> accum_s_mask(seqlen_q, seqlen_k);
 
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tQgQ, tQsQ, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tQgQ, tQsQ, tCqQ, 
         seqlen_q - m_block * kBlockM, 
         /*clear_D=*/true);
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tdOgdO, tdOsdO, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tdOgdO, tdOsdO, tCqQ, 
         seqlen_q - m_block * kBlockM, 
         /*clear_D=*/true);
 
@@ -362,11 +368,11 @@ inline __device__ void compute_dq_1rowblock(
         clear(tdPrdP_float);
 
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tKgK(_,_,_,n_block), tKrK, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tKgK(_,_,_,n_block), tKrK, tCqK, 
             seqlen_k - n_block * kBlockN, 
             /*clear_D=*/true);
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tVgV(_,_,_,n_block), tVrV, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tVgV(_,_,_,n_block), tVrV, tCqK, 
             seqlen_k - n_block * kBlockN, 
             /*clear_D=*/true);
         copy(gmem_tiled_copy_QKV, tKrK, tKsK);
@@ -601,7 +607,7 @@ inline __device__ void compute_dq_1rowblock(
 
 
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tdQsdQ_copy, tdQgdQ_copy, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tdQsdQ_copy, tdQgdQ_copy, tCqQ, 
         seqlen_q - m_block * kBlockM, 
         /*clear_D=*/false);
 
@@ -803,6 +809,12 @@ inline __device__ void compute_dk_dv_1colblock(
     Tensor tdVsdV_copy = thr_copy_QKV.partition_S(sdV);
     Tensor tdVgdV_copy = thr_copy_QKV.partition_D(gdV);
 
+    // Identity tensors for bound-checking the masked copies
+    Tensor cQ_identity = make_identity_tensor(make_shape(Int<kBlockM>{}, Int<kHeadDim>{}));
+    Tensor cK_identity = make_identity_tensor(make_shape(Int<kBlockN>{}, Int<kHeadDim>{}));
+    auto tCqQ = thr_copy_QKV.partition_S(cQ_identity);
+    auto tCqK = thr_copy_QKV.partition_S(cK_identity);
+
 
 
     // S = QK^T
@@ -936,11 +948,11 @@ inline __device__ void compute_dk_dv_1colblock(
 
     
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tKgK, tKsK, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tKgK, tKsK, tCqK, 
         seqlen_k - n_block * kBlockN, 
         /*clear_D=*/true);
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tVgV, tVrV, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tVgV, tVrV, tCqK, 
         seqlen_k - n_block * kBlockN, 
         /*clear_D=*/true);
 
@@ -967,11 +979,11 @@ inline __device__ void compute_dk_dv_1colblock(
         // load gQ to sQ
 
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tQgQ(_,_,_,m_block), tQsQ, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tQgQ(_,_,_,m_block), tQsQ, tCqQ, 
             seqlen_q - m_block * kBlockM, 
             /*clear_D=*/true);
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tdOgdO(_,_,_,m_block), tdOsdO, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tdOgdO(_,_,_,m_block), tdOsdO, tCqQ, 
             seqlen_q - m_block * kBlockM, 
             /*clear_D=*/true);
 
@@ -1094,7 +1106,7 @@ inline __device__ void compute_dk_dv_1colblock(
 
         // copy(gmem_tiled_copy_QKV, tVsV, tVrV);
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tVsV, tVrV, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tVsV, tVrV, tCqK, 
             seqlen_k - n_block * kBlockN, 
             /*clear_D=*/true);
 
@@ -1164,11 +1176,11 @@ inline __device__ void compute_dk_dv_1colblock(
     //    copy(gmem_tiled_copy_QKV, tdOgdO(_,_,_,m_block), tdOsdO);
 
          masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tQgQ(_,_,_,m_block), tQsQ, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tQgQ(_,_,_,m_block), tQsQ, tCqQ, 
             seqlen_q - m_block * kBlockM, 
             /*clear_D=*/true);
          masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QKV, tdOgdO(_,_,_,m_block), tdOsdO, warp_id, lane_id, 
+            gmem_tiled_copy_QKV, tdOgdO(_,_,_,m_block), tdOsdO, tCqQ, 
             seqlen_q - m_block * kBlockM, 
             /*clear_D=*/true);
 
@@ -1332,11 +1344,11 @@ inline __device__ void compute_dk_dv_1colblock(
 
     //store to gmem
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tdKsdK_copy, tdKgdK_copy, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tdKsdK_copy, tdKgdK_copy, tCqK, 
         seqlen_k - n_block * kBlockN, 
         /*clear_D=*/false);
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QKV, tdVsdV_copy, tdVgdV_copy, warp_id, lane_id, 
+        gmem_tiled_copy_QKV, tdVsdV_copy, tdVgdV_copy, tCqK, 
         seqlen_k - n_block * kBlockN, 
         /*clear_D=*/false);
 

--- a/csrc/flash_attn/src/flash_bwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_bwd_launch_template.h
@@ -159,6 +159,18 @@ void run_mha_bwd_hdim64(Flash_bwd_params &params) {
 }
 
 
+template<bool Is_causal>
+void run_mha_bwd_hdim96(Flash_bwd_params &params) {
+    constexpr static int Headdim = 96;
+    constexpr static int kBlockM = 64;
+    constexpr static int kBlockN = 64;
+    constexpr static int kNWarps = 8;
+
+    run_flash_bwd<Flash_bwd_kernel_traits<Headdim, kBlockM, kBlockN, kNWarps>, Is_causal>(params);
+
+
+}
+
 
 template<bool Is_causal>
 void run_mha_bwd_hdim128(Flash_bwd_params &params) {

--- a/csrc/flash_attn/src/flash_bwd_preprocess_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_preprocess_kernel.h
@@ -63,6 +63,8 @@ inline __device__ void compute_dot_do_o(half_t* o_ptr,
     int elements_per_thread = 0;
     if constexpr (kHeadDim == 64) {
         elements_per_thread = 2;
+    } else if constexpr (kHeadDim == 96) {
+        elements_per_thread = 3;
     } else {
         elements_per_thread = 4;
     }

--- a/csrc/flash_attn/src/flash_fwd_hdim96_fp16_causal_sm75.cu
+++ b/csrc/flash_attn/src/flash_fwd_hdim96_fp16_causal_sm75.cu
@@ -1,0 +1,10 @@
+#include "flash_fwd_launch_template.h"
+
+#include <cutlass/numeric_types.h>
+
+using half_t = cutlass::half_t;
+
+template<>
+void run_mha_fwd_<96, true>(Flash_fwd_params &params) {
+    run_mha_fwd_hdim96<true>(params);
+}

--- a/csrc/flash_attn/src/flash_fwd_hdim96_fp16_sm75.cu
+++ b/csrc/flash_attn/src/flash_fwd_hdim96_fp16_sm75.cu
@@ -1,0 +1,10 @@
+#include "flash_fwd_launch_template.h"
+
+#include <cutlass/numeric_types.h>
+
+using half_t = cutlass::half_t;
+
+template<>
+void run_mha_fwd_<96, false>(Flash_fwd_params &params) {
+    run_mha_fwd_hdim96<false>(params);
+}

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -173,6 +173,13 @@ inline __device__ void compute_attn_1rowblock(
     Tensor tOsO_copy = thr_copy_O.partition_S(sO);
     Tensor tOgO_copy = thr_copy_O.partition_D(gO);
 
+    // Identity tensors for bound-checking the masked copies
+    Tensor cQ_identity = make_identity_tensor(make_shape(Int<kBlockM>{}, Int<kHeadDim>{}));
+    Tensor cK_identity = make_identity_tensor(make_shape(Int<kBlockN>{}, Int<kHeadDim>{}));
+    auto tCqQ = thr_copy_QK.partition_S(cQ_identity);
+    auto tCqK = thr_copy_QK.partition_S(cK_identity);
+    auto tCqO = thr_copy_O.partition_S(cQ_identity);
+
 
     typename Kernel_traits::TiledMma tiled_mma;
 
@@ -249,7 +256,7 @@ inline __device__ void compute_attn_1rowblock(
 
     // copy(gmem_tiled_copy_QK, tQgQ, tQsQ);
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QK, tQgQ, tQsQ, warp_id, lane_id, 
+        gmem_tiled_copy_QK, tQgQ, tQsQ, tCqQ, 
         seqlen_q - m_block * kBlockM, 
         /*clear_D=*/true);
 
@@ -264,7 +271,7 @@ inline __device__ void compute_attn_1rowblock(
     // constexpr bool Is_even_MN = true; 
 
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_QK, tKgK(_,_,_,n_block), tKrK, warp_id, lane_id, 
+        gmem_tiled_copy_QK, tKgK(_,_,_,n_block), tKrK, tCqK, 
         seqlen_k - n_block * kBlockN,
         /*clear_D=*/true);
     //copy(gmem_tiled_copy_QK, tKgK(_,_,_,n_block), tKrK);
@@ -284,7 +291,7 @@ inline __device__ void compute_attn_1rowblock(
         if (n_block > n_block_min) {
 
             masked_copy<Is_even_MN>(
-                gmem_tiled_copy_QK, tKgK(_,_,_,n_block-1), tKrK, warp_id, lane_id, 
+                gmem_tiled_copy_QK, tKgK(_,_,_,n_block-1), tKrK, tCqK, 
                 seqlen_k - (n_block-1) * kBlockN,
                 /*clear_D=*/true);
             // copy(gmem_tiled_copy_QK, tKgK(_,_,_,n_block - 1 ), tKrK);
@@ -301,7 +308,7 @@ inline __device__ void compute_attn_1rowblock(
 
         __syncthreads();
         masked_copy<Is_even_MN>(
-            gmem_tiled_copy_QK, tVgV(_,_,_,n_block), tVsV, warp_id, lane_id, 
+            gmem_tiled_copy_QK, tVgV(_,_,_,n_block), tVsV, tCqK, 
             seqlen_k - n_block * kBlockN,
             /*clear_D=*/true);
 
@@ -636,7 +643,7 @@ inline __device__ void compute_attn_1rowblock(
 
     //copy(gmem_tiled_copy_O, tOsO_copy, tOgO_copy);
     masked_copy<Is_even_MN>(
-        gmem_tiled_copy_O, tOsO_copy, tOgO_copy, warp_id, lane_id, 
+        gmem_tiled_copy_O, tOsO_copy, tOgO_copy, tCqO, 
         seqlen_q - m_block * kBlockM, 
         /*clear_D=*/false);
 

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -103,6 +103,18 @@ void run_mha_fwd_hdim128(Flash_fwd_params &params) {
 
 
 template<bool Is_causal>
+void run_mha_fwd_hdim96(Flash_fwd_params &params) {
+    constexpr static int Headdim = 96;
+    constexpr static int kBlockM = 128;
+    constexpr static int kBlockN = 64;
+    constexpr static int kNWarps = 8;
+    run_flash_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, kNWarps>, Is_causal>(params);
+
+
+}
+
+
+template<bool Is_causal>
 void run_mha_fwd_hdim64(Flash_fwd_params &params) {
     constexpr static int Headdim = 64;
     constexpr static int kBlockM = 128;

--- a/csrc/flash_attn/src/kernel_traits.h
+++ b/csrc/flash_attn/src/kernel_traits.h
@@ -61,10 +61,11 @@ struct Flash_fwd_kernel_traits : public Base {
         // LDSM loads 32 rows for K and V
         Tile<_128, _32, _8>>;
 
-    using SmemLayoutAtomQK = decltype(
-        composition(Swizzle<3, 3, 3>{},
-                    Layout<Shape<_16, _64>,
-                    Stride<_64, _1>>{}));
+    using SmemLayoutAtomQK = std::conditional_t<
+        kHeadDim == 96,
+        decltype(composition(Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{})),
+        decltype(composition(Swizzle<3, 3, 3>{}, Layout<Shape<_16, _64>, Stride<_64, _1>>{}))
+    >;
 
     using SmemLayoutQ = decltype(tile_to_shape(
         SmemLayoutAtomQK{},
@@ -85,10 +86,11 @@ struct Flash_fwd_kernel_traits : public Base {
     //     SmemLayoutAtomV{},
     //     Shape<Int<kHeadDim>, Int<kBlockN>>{}));
 
-    using SmemLayoutAtomV = decltype(
-        composition(Swizzle<3, 3, 3>{},
-                    Layout<Shape<_16, _64>,
-                    Stride<_64, _1>>{}));
+    using SmemLayoutAtomV = std::conditional_t<
+        kHeadDim == 96,
+        decltype(composition(Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{})),
+        decltype(composition(Swizzle<3, 3, 3>{}, Layout<Shape<_16, _64>, Stride<_64, _1>>{}))
+    >;
 
     using SmemLayoutV = decltype(tile_to_shape(
         SmemLayoutAtomV{},
@@ -98,13 +100,22 @@ struct Flash_fwd_kernel_traits : public Base {
         composition(SmemLayoutV{}, make_layout(Shape<Int<kHeadDim>, Int<kBlockN>>{}, GenRowMajor{})));
 
 
-    using GmemLayoutAtomQK = Layout<Shape <_32, _8>, Stride<_8, _1>>;
+    using GmemLayoutAtomQK = std::conditional_t<
+        kHeadDim == 96,
+        Layout<Shape<_64, _4>, Stride<_4, _1>>,
+        Layout<Shape<_32, _8>, Stride<_8, _1>>>;
 
     // using GmemLayoutAtomV = Layout<Shape <_8, _32>, Stride<_1, _8>>;
-    using GmemLayoutAtomV = Layout<Shape <_32, _8>, Stride<_8, _1>>;
+    using GmemLayoutAtomV = std::conditional_t<
+        kHeadDim == 96,
+        Layout<Shape<_64, _4>, Stride<_4, _1>>,
+        Layout<Shape<_32, _8>, Stride<_8, _1>>>;
 
 
-    using GmemLayoutAtomO = Layout<Shape <_32, _8>, Stride<_8, _1>>;
+    using GmemLayoutAtomO = std::conditional_t<
+        kHeadDim == 96,
+        Layout<Shape<_64, _4>, Stride<_4, _1>>,
+        Layout<Shape<_32, _8>, Stride<_8, _1>>>;
 
 
     using GmemTiledCopyQK = decltype(
@@ -154,12 +165,18 @@ struct Flash_bwd_kernel_traits : public Base {
     using TiledMma_dQ = TiledMMA<
         typename Base::MMA_Atom_Arch,
         Layout<Shape<_2, Int<kNWarps/2>, _1>>,
-        Tile<Int<kBlockM>, Int<kHeadDim>, _8>>;
+        std::conditional_t<kHeadDim == 96,
+            Tile<Int<kBlockM>, Int<32>, _8>,
+            Tile<Int<kBlockM>, Int<kHeadDim>, _8>
+        >>;
 
     using TiledMma_dKdV = TiledMMA<
         typename Base::MMA_Atom_Arch,
         Layout<Shape<_2, Int<kNWarps/2>, _1>>,
-        Tile<Int<kBlockN>, Int<kHeadDim>, _8>>;
+        std::conditional_t<kHeadDim == 96,
+            Tile<Int<kBlockN>, Int<32>, _8>,
+            Tile<Int<kBlockN>, Int<kHeadDim>, _8>
+        >>;
 
 
     using SmemLayoutAtomPdS = decltype(
@@ -177,9 +194,11 @@ struct Flash_bwd_kernel_traits : public Base {
 
     // QKV
     // swizzle atom
-    using SmemLayoutAtomQKV = decltype(composition(Swizzle<3, 3, 3>{},
-                                Layout<Shape<_16,_64>,
-                                Stride<_64, _1>>{}));
+    using SmemLayoutAtomQKV = std::conditional_t<
+        kHeadDim == 96,
+        decltype(composition(Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{})),
+        decltype(composition(Swizzle<3, 3, 3>{}, Layout<Shape<_16, _64>, Stride<_64, _1>>{}))
+    >;
 
     // swizzle Q
     using SmemLayoutQ = decltype(tile_to_shape(
@@ -190,10 +209,11 @@ struct Flash_bwd_kernel_traits : public Base {
                       composition(SmemLayoutQ{}, make_layout(Shape<Int<kHeadDim>, Int<kBlockM>>{}, GenRowMajor{})));
 
     // swizzle K
-    using SmemLayoutAtomKV = decltype(
-        composition(Swizzle<3, 3, 3>{},
-                    Layout<Shape<Int<16>, Int<64>>,
-                           Stride<Int<64>, _1>>{}));
+    using SmemLayoutAtomKV = std::conditional_t<
+        kHeadDim == 96,
+        decltype(composition(Swizzle<2, 3, 3>{}, Layout<Shape<Int<8>, Int<32>>, Stride<Int<32>, _1>>{})),
+        decltype(composition(Swizzle<3, 3, 3>{}, Layout<Shape<Int<16>, Int<64>>, Stride<Int<64>, _1>>{}))
+    >;
 
     using SmemLayoutKV = decltype(tile_to_shape(
         // SmemLayoutAtomQdO{},
@@ -228,32 +248,48 @@ struct Flash_bwd_kernel_traits : public Base {
     using SmemCopyAtomKt = std::conditional_t<
         kHeadDim == 64,
         Copy_Atom<SM75_U16x4_LDSM_T, elem_type>,
-        Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        std::conditional_t<kHeadDim == 96,
+            Copy_Atom<SM75_U16x2_LDSM_T, elem_type>,
+            Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        >
     >;
 
     using SmemCopyAtomQt = std::conditional_t<
         kHeadDim == 64,
         Copy_Atom<SM75_U16x4_LDSM_T, elem_type>,
-        Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        std::conditional_t<kHeadDim == 96,
+            Copy_Atom<SM75_U16x2_LDSM_T, elem_type>,
+            Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        >
     >;
 
 
     using SmemCopyAtomdOt = std::conditional_t<
         kHeadDim == 64,
         Copy_Atom<SM75_U16x4_LDSM_T, elem_type>,
-        Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        std::conditional_t<kHeadDim == 96,
+            Copy_Atom<SM75_U16x2_LDSM_T, elem_type>,
+            Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+        >
     >;
 
     // using SmemCopyAtomQtdOtPtdSt = Copy_Atom<SM75_U16x8_LDSM_T, elem_type>;
 
-    using SmemCopyAtomPtdSt = Copy_Atom<SM75_U16x8_LDSM_T, elem_type>;
+    using SmemCopyAtomPtdSt = std::conditional_t<
+        kHeadDim == 96,
+        Copy_Atom<SM75_U16x2_LDSM_T, elem_type>,
+        Copy_Atom<SM75_U16x8_LDSM_T, elem_type>
+    >;
 
 
 
 
 
     //gmem loads
-    using GmemLayoutAtom = Layout<Shape <_32, _8>, Stride<_8, _1>>;
+    using GmemLayoutAtom = std::conditional_t<
+        kHeadDim == 96,
+        Layout<Shape<_64, _4>, Stride<_4, _1>>,
+        Layout<Shape<_32, _8>, Stride<_8, _1>>>;
 
     using GmemTiledCopy = decltype(
             make_tiled_copy(Copy_Atom<typename Base::Gmem_copy_struct, Element>{},

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -31,6 +31,9 @@
       if (HEADDIM == 64) {                   \
         constexpr static int kHeadDim = 64;  \
         return __VA_ARGS__();                 \
+      } else if (HEADDIM == 96) {            \
+        constexpr static int kHeadDim = 96;  \
+        return __VA_ARGS__();                 \
       } else if (HEADDIM == 128) {           \
         constexpr static int kHeadDim = 128;   \
         return __VA_ARGS__();                 \

--- a/csrc/flash_attn/src/utils.h
+++ b/csrc/flash_attn/src/utils.h
@@ -47,18 +47,16 @@ __device__ __forceinline__ float operator()(float const &x, float const &y) { re
 
 
 template <bool Is_even_MN=true,
-            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1>
+            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1,
+            typename Engine2, typename Layout2>
 __forceinline__ __device__ void masked_copy_store(TiledCopy tiled_copy, Tensor<Engine0, Layout0> const &S,
-                            Tensor<Engine1, Layout1> &D, const int warp_id, const int lane_id, const int max_MN=0) {
+                            Tensor<Engine1, Layout1> &D, Tensor<Engine2, Layout2> const &identity_MN, const int max_MN=0) {
 
     // There's no case where !Clear_OOB_K && Clear_OOB_MN
-    const int row_offset = warp_id * 4 + lane_id / 8;
     #pragma unroll
     for (int m = 0; m < size<1>(S); ++m) {
-        int row = row_offset + m * 32;
-        if (Is_even_MN || row < max_MN) {
+        if (Is_even_MN || (int)get<0>(identity_MN(0, m, 0)) < max_MN) {
             cute::copy(tiled_copy, S(_, m, _), D(_, m, _));
-//            printf("loading row = %d, warp_id = %d, lane_id = %d\n", row, warp_id, lane_id);
         }
 //        } else {
 //            cute::clear(D(_, m, _));
@@ -68,18 +66,16 @@ __forceinline__ __device__ void masked_copy_store(TiledCopy tiled_copy, Tensor<E
 
 
 template <bool Is_even_MN=true,
-            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1>
+            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1,
+            typename Engine2, typename Layout2>
 __forceinline__ __device__ void masked_copy_read(TiledCopy tiled_copy, Tensor<Engine0, Layout0> const &S,
-                            Tensor<Engine1, Layout1> &D, const int warp_id, const int lane_id, const int max_MN=0) {
+                            Tensor<Engine1, Layout1> &D, Tensor<Engine2, Layout2> const &identity_MN, const int max_MN=0) {
 
     // There's no case where !Clear_OOB_K && Clear_OOB_MN
-    const int row_offset = warp_id * 4 + lane_id / 8;
     #pragma unroll
     for (int m = 0; m < size<1>(S); ++m) {
-        int row = row_offset + m * 32;
-        if (Is_even_MN || row < max_MN) {
+        if (Is_even_MN || (int)get<0>(identity_MN(0, m, 0)) < max_MN) {
             cute::copy(tiled_copy, S(_, m, _), D(_, m, _));
-//            printf("loading row = %d, warp_id = %d, lane_id = %d\n", row, warp_id, lane_id);
         } else {
             cute::clear(D(_, m, _));
         }
@@ -87,18 +83,17 @@ __forceinline__ __device__ void masked_copy_read(TiledCopy tiled_copy, Tensor<En
 }
 
 template <bool Is_even_MN=true,
-            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1>
+            typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1,
+            typename Engine2, typename Layout2>
 __forceinline__ __device__ void masked_copy(TiledCopy tiled_copy, Tensor<Engine0, Layout0> const &S,
-                            Tensor<Engine1, Layout1> &D, const int warp_id, const int lane_id, const int max_MN=0, const bool clear_D=true) {
+                            Tensor<Engine1, Layout1> &D, Tensor<Engine2, Layout2> const &identity_MN,
+                            const int max_MN=0, const bool clear_D=true) {
 
     // There's no case where !Clear_OOB_K && Clear_OOB_MN
-    const int row_offset = warp_id * 4 + lane_id / 8;
     #pragma unroll
     for (int m = 0; m < size<1>(S); ++m) {
-        int row = row_offset + m * 32;
-        if (Is_even_MN || row < max_MN) {
+        if (Is_even_MN || (int)get<0>(identity_MN(0, m, 0)) < max_MN) {
             cute::copy(tiled_copy, S(_, m, _), D(_, m, _));
-//            printf("loading row = %d, warp_id = %d, lane_id = %d\n", row, warp_id, lane_id);
         } else if (clear_D){
             cute::clear(D(_, m, _));
         }

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 import os
+import sys
 from pathlib import Path
 import subprocess
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 if os.path.isdir(".git"):
     subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"], check=True)
@@ -17,6 +19,12 @@ nvcc_flags = ["-std=c++17",
               "--ptxas-options=-v",
               "-lineinfo"]
 
+if sys.platform == "win32":
+    from distutils import ccompiler
+    compiler = ccompiler.new_compiler()
+    if compiler.compiler_type == "msvc":
+        nvcc_flags[0] = "-std=c++20"
+        nvcc_flags.extend(["-Xcompiler", "/Zc:preprocessor"])
 setup(
     name="flash_attn_turing",
     ext_modules=[
@@ -25,10 +33,14 @@ setup(
             sources=["csrc/flash_attn/flash_api.cpp",
                      "csrc/flash_attn/src/flash_fwd_hdim64_fp16_sm75.cu",
                      "csrc/flash_attn/src/flash_fwd_hdim64_fp16_causal_sm75.cu",
+                     "csrc/flash_attn/src/flash_fwd_hdim96_fp16_sm75.cu",
+                     "csrc/flash_attn/src/flash_fwd_hdim96_fp16_causal_sm75.cu",
                      "csrc/flash_attn/src/flash_fwd_hdim128_fp16_sm75.cu",
                      "csrc/flash_attn/src/flash_fwd_hdim128_fp16_causal_sm75.cu",
                      "csrc/flash_attn/src/flash_bwd_hdim64_fp16_sm75.cu",
                      "csrc/flash_attn/src/flash_bwd_hdim64_fp16_causal_sm75.cu",
+                     "csrc/flash_attn/src/flash_bwd_hdim96_fp16_sm75.cu",
+                     "csrc/flash_attn/src/flash_bwd_hdim96_fp16_causal_sm75.cu",
                      "csrc/flash_attn/src/flash_bwd_hdim128_fp16_sm75.cu",
                      "csrc/flash_attn/src/flash_bwd_hdim128_fp16_causal_sm75.cu"
                      ],

--- a/test_flash_attn.py
+++ b/test_flash_attn.py
@@ -44,7 +44,7 @@ BWD_TOLS = dict(
 )
 
 DTYPES = [torch.float16]
-HEAD_DIMS = [64, 128]
+HEAD_DIMS = [64, 96, 128]
 BATCH_SIZES = [1, 3]
 SOFTMAX_SCALES = [None, 0.3]
 # SOFTMAX_SCALES = [0.3]

--- a/utils/plot_kernels.py
+++ b/utils/plot_kernels.py
@@ -205,7 +205,7 @@ def compute_speed_up(df):
 
     return df
 
-HDIMS = [64, 128]
+HDIMS = [64, 96, 128]
 SEQLENS  = [500, 512, 1000, 1024, 2000, 2048, 4000, 4096, 8000, 8192, 16000, 16384]
 IS_CAUSALS = ["False", "True"]
 


### PR DESCRIPTION
## Summary
Adds fp16 head-dim 96: forward and backward, causal and non-causal, via the existing static_switch (gqa/varlen compatible).

- fwd: 128x64 tile, Swizzle<2,3,3> (8,32) smem atoms, (64,4) gmem copy atom(4 threads per row, 16B loads) - mirrors upstream flash-attention's hdim-96 layout scheme.
- bwd: 64x64 tile, dQ/dKdV mma tiles split into 32-wide K chunks with matching SM75_U16x2 LDSM copies.
- Generalizes `masked_copy` row bound-checking: replaces the hardcoded(32x8)-geometry formula with per-thread identity-tensor coordinates(`get<0>(identity_MN(0,m,0))`). Required for the (64,4) atom; fixes OOB accesses on partial tail blocks (seqlen not a multiple of the block size); behavior-neutral for head dims 64/128.
- Also adds 96 to the test matrix, README, and benchmark script.

## Tests
- `test_flash_attn.py` passes on a T4 (sm_75): head dims 64/96/128, seqlen 500/512/1000/1024 plus arbitrary lengths, causal and non-causal, fwd+bwd all within tolerance.
- Performance: benchmark could not be run in the available environment. `benchmark.sh` already includes hdim 96; would appreciate a maintainer run or CI benchmark on T4.